### PR TITLE
feat: add tags for Matomo

### DIFF
--- a/blog/docusaurus.config.js
+++ b/blog/docusaurus.config.js
@@ -102,6 +102,13 @@ const config = {
 	plugins: [
 		'docusaurus-plugin-fathom',
 	],
+	
+	scripts: [
+		{
+			src: '/js/loadtags.js',
+			async: false,
+		},
+	],
 };
 
 export default config;

--- a/blog/package-lock.json
+++ b/blog/package-lock.json
@@ -12,7 +12,7 @@
         "@docusaurus/preset-classic": "3.4.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
-        "docusaurus-plugin-fathom": "^1.2.0",
+        "docusaurus-plugin-matomo": "0.0.8",
         "prism-react-renderer": "^2.3.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
@@ -5985,13 +5985,16 @@
         "node": ">=6"
       }
     },
-    "node_modules/docusaurus-plugin-fathom": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-fathom/-/docusaurus-plugin-fathom-1.2.0.tgz",
-      "integrity": "sha512-F6ieKLOqYfaBTtaCRXzb/aLBjKfX8LOUN3L+6DSp4hcXqPbs41Lvqt/CkOAUujP+qViUajQ7oB5gfUi33CHmWw==",
+    "node_modules/docusaurus-plugin-matomo": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-matomo/-/docusaurus-plugin-matomo-0.0.8.tgz",
+      "integrity": "sha512-YSaDdjxI7uN1FuNLSGrQy4BmDEXwwyL6vac7GfmS7wFBLck/Ias5jHqENPBHXe36m2cYzyesGPQL1EsS9vanwA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      },
       "peerDependencies": {
-        "@docusaurus/core": "^2.0.0 || ^3.0.0"
+        "@docusaurus/core": "^2.0.0-alpha.56 || ^3.0.0"
       }
     },
     "node_modules/dom-converter": {

--- a/cli-releases/frontend/src/app.html
+++ b/cli-releases/frontend/src/app.html
@@ -10,14 +10,21 @@
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 
-  <!-- Fathom - beautiful, simple website analytics -->
-  <script
-    src="https://cdn.usefathom.com/script.js"
-    data-spa="auto"
-    data-site="THOISMFA"
-    defer
-  ></script>
-  <!-- / Fathom -->
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://internetcomputer.matomo.cloud/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '18']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src='https://cdn.matomo.cloud/internetcomputer.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
 </html>
 
 <style>

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -101,6 +101,13 @@ const config = {
 	plugins: [
 		'docusaurus-plugin-fathom',
 	],
+	
+	scripts: [
+		{
+			src: '/js/loadtags.js',
+			async: false,
+		},
+	],
 };
 
 module.exports = config;

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
         "@docusaurus/preset-classic": "2.4.3",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
-        "docusaurus-plugin-fathom": "1.1.0",
+        "docusaurus-plugin-matomo": "0.0.8",
         "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
@@ -5628,12 +5628,16 @@
         "node": ">=6"
       }
     },
-    "node_modules/docusaurus-plugin-fathom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/docusaurus-plugin-fathom/-/docusaurus-plugin-fathom-1.1.0.tgz",
-      "integrity": "sha512-MVMYb2daXLho8Foaxl2ipTCH3RWEmV5plQytGa8tMk3LOiWcZ5S9TcOhcAB9W5b9ZeebyotWYXpTnsLyXgKFgA==",
+    "node_modules/docusaurus-plugin-matomo": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-matomo/-/docusaurus-plugin-matomo-0.0.8.tgz",
+      "integrity": "sha512-YSaDdjxI7uN1FuNLSGrQy4BmDEXwwyL6vac7GfmS7wFBLck/Ias5jHqENPBHXe36m2cYzyesGPQL1EsS9vanwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13.0"
+      },
       "peerDependencies": {
-        "@docusaurus/core": "^2.0.0"
+        "@docusaurus/core": "^2.0.0-alpha.56 || ^3.0.0"
       }
     },
     "node_modules/dom-converter": {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,14 +9,21 @@
 
 <link rel="shortcut icon" href="/img/mops-motoko.svg" type="image/x-icon" />
 
-<!-- Fathom - beautiful, simple website analytics -->
-<script
-  src="https://cdn.usefathom.com/script.js"
-  data-spa="auto"
-  data-site="THOISMFA"
-  defer
-></script>
-<!-- / Fathom -->
+<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="https://internetcomputer.matomo.cloud/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '18']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src='https://cdn.matomo.cloud/internetcomputer.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
 
 <script type="module">
   /**


### PR DESCRIPTION
This PR includes analytics tags for Matomo. The goal is to fully migrate away from Fathom once fully configured.